### PR TITLE
Closes #7 add ability to log in via ui

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -39,7 +39,15 @@ tooling:
   # Provide a command to install Drupal.
   install:
     service: appserver
-    cmd: /app/vendor/bin/drush --root=/app/web site:install --account-mail=noreply@email.arizona.edu --account-name=azadmin --account-pass=azadmin --db-url=mysql://drupal9:drupal9@database:3306/drupal9 -y --verbose && /app/vendor/bin/drush en -y azqs_module_project
+    cmd:
+      - /app/vendor/bin/drush --root=/app/web site:install
+        --account-mail=noreply@email.arizona.edu --account-name=azadmin
+        --account-pass=azadmin
+        --db-url=mysql://drupal9:drupal9@database:3306/drupal9 -y --verbose
+      - /app/vendor/bin/drush en -y azqs_module_project
+      - /app/vendor/bin/drush --root=/app/web config:set -y az_cas.settings disable_login_form 0
+      - /app/vendor/bin/drush --root=/app/web cache:rebuild
+
   # Provide Drush tooling to automatically know the Drupal root.
   drush:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -44,7 +44,7 @@ tooling:
         --account-mail=noreply@email.arizona.edu --account-name=azadmin
         --account-pass=azadmin
         --db-url=mysql://drupal9:drupal9@database:3306/drupal9 -y --verbose
-      - /app/vendor/bin/drush en -y azqs_module_project
+      - /app/vendor/bin/drush --root=/app/web pm:install -y azqs_module_project
       - /app/vendor/bin/drush --root=/app/web config:set -y az_cas.settings disable_login_form 0
       - /app/vendor/bin/drush --root=/app/web cache:rebuild
 


### PR DESCRIPTION
Since disabling the log in form for security reasons in az_quickstart, we need to reenable it in lando so people can log into their development testing sites via the UI.					